### PR TITLE
Add Checkstyle dependency to maven-checkstyle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -693,6 +693,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.6.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>13.7.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This is Java 25 / 26 support. It was already in plugins section, but it seems that specifying there is not enough for child projects to use the correct version.